### PR TITLE
Modify to flag recipe first before duplicated URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## August 13, 2024 <a id="august-13-2024"></a>
+
 - Modified `flag_articles_to_remove_after_extraction` function to flag for recipe first before duplicated URL/content in `data_processing/utils.py`
 - Remove recipe from whitelist (except for article `1445704` and `1445707`)
 - Change `Irrelevant Content` flag to `No relevant content and mainly links`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## August 13, 2024 <a id="august-13-2024"></a>
+- Modified `flag_articles_to_remove_after_extraction` function to flag for recipe first before duplicated URL/content in `data_processing/utils.py`
+- Remove recipe from whitelist (except for article `1445704` and `1445707`)
+- Change `Irrelevant Content` flag to `No relevant content and mainly links`
+
 ## August 8, 2024 <a id="august-8-2024"></a>
 
 - Added `blacklist` dictionary in `parameters_data_processing.yml` with remove_type description

--- a/content-optimization/conf/base/parameters_data_processing.yml
+++ b/content-optimization/conf/base/parameters_data_processing.yml
@@ -322,8 +322,8 @@ whitelist:
   - 1497409 # flagged as duplicated content but whitelisted
   - 1469472 # flagged as duplicated content but whitelisted
   - 1446081 # flagged as duplicated url but whitelisted
-  - 1445828 # flagged as duplicated url but whitelisted
-  - 1445798 # flagged as duplicated url but whitelisted
+  # - 1445828 # flagged as duplicated url but whitelisted, also a recipe
+  # - 1445798 # flagged as duplicated url but whitelisted, also a recipe
   - 1435335 # flagged as duplicated url but whitelisted
   - 1435183 # flagged as duplicated url but whitelisted
   - 1434614 # flagged as duplicated url but whitelisted
@@ -334,11 +334,11 @@ whitelist:
 blacklist:
   1443526: "Table of Contents"
   1443534: "Table of Contents"
-  1444997: "Irrelevant Content"
-  1445002: "Irrelevant Content"
-  1444991: "Irrelevant Content"
-  1444996: "Irrelevant Content"
-  1445000: "Irrelevant Content"
+  1444997: "No relevant content and mainly link"
+  1445002: "No relevant content and mainly link"
+  1444991: "No relevant content and mainly link"
+  1444996: "No relevant content and mainly link"
+  1445000: "No relevant content and mainly link"
 
 # Refer to https://docs.google.com/spreadsheets/d/1bcmD7GXILn4LqF0Bo9dcdCnRomwCVFQv (IA Mappings)
 l1_mappings:

--- a/content-optimization/conf/base/parameters_data_processing.yml
+++ b/content-optimization/conf/base/parameters_data_processing.yml
@@ -334,11 +334,11 @@ whitelist:
 blacklist:
   1443526: "Table of Contents"
   1443534: "Table of Contents"
-  1444997: "No relevant content and mainly link"
-  1445002: "No relevant content and mainly link"
-  1444991: "No relevant content and mainly link"
-  1444996: "No relevant content and mainly link"
-  1445000: "No relevant content and mainly link"
+  1444997: "No relevant content and mainly links"
+  1445002: "No relevant content and mainly links"
+  1444991: "No relevant content and mainly links"
+  1444996: "No relevant content and mainly links"
+  1445000: "No relevant content and mainly links"
 
 # Refer to https://docs.google.com/spreadsheets/d/1bcmD7GXILn4LqF0Bo9dcdCnRomwCVFQv (IA Mappings)
 l1_mappings:

--- a/content-optimization/src/content_optimization/pipelines/data_processing/utils.py
+++ b/content-optimization/src/content_optimization/pipelines/data_processing/utils.py
@@ -435,9 +435,9 @@ def flag_articles_to_remove_after_extraction(
         pd.DataFrame: The DataFrame with updated flags for articles to remove.
     """
     df = flag_no_extracted_content(df, whitelist)
+    df = flag_recipe_articles(df, whitelist)
     df = flag_duplicated(df, whitelist, column="extracted_content_body")
     df = flag_duplicated(df, whitelist, column="full_url")
-    df = flag_recipe_articles(df, whitelist)
     df = flag_multilingual_content(df, whitelist)
     df = flag_below_word_count_cutoff(df, word_count_cutoff, whitelist)
     df = flag_articles_via_blacklist(df, blacklist)


### PR DESCRIPTION
## data_processing/utils.py
- Modified flag_articles_to_remove_after_extraction function to flag for recipe first before duplicated URL/content

## parameters_data_processing.yml
- Remove recipe from whitelist
- Change 'Irrelevant Content' flag to 'No relevant content and mainly link'