### PR TITLE
Article harmonisation ij

### DIFF
--- a/article-harmonisation/agents/models.py
+++ b/article-harmonisation/agents/models.py
@@ -649,38 +649,39 @@ class Azure(LLMInterface):
                     }
                 )
 
-            case "structure":
-                # Set up prompts for structure evaluation and decision-making
-                evaluation_prompt = ChatPromptTemplate.from_messages(
-                    self.prompt_template.return_structure_evaluation_prompt()
-                )
-                decision_prompt = ChatPromptTemplate.from_messages(
-                    self.prompt_template.return_decision_prompt()
-                )
-
-                # Create evaluation chain
-                evaluation_chain = (
-                    evaluation_prompt
-                    | self.model
-                    | StrOutputParser()
-                    | {"evaluation": RunnablePassthrough()}
-                )
-
-                # Create decision chain
-                decision_chain = (
-                    decision_prompt
-                    | self.model
-                    | StrOutputParser()
-                    | RunnableLambda(parse_string_to_boolean)
-                )
-
-                # Combine chains for structure evaluation
-                chain = (
-                    evaluation_chain
-                    | {"text": itemgetter("evaluation")}
-                    | RunnableParallel(text=itemgetter("text"), decision=decision_chain)
-                    | RunnableLambda(self.evaluation_summary_router)
-                )
+            # # NOTE: Code is commented out as the Writing Style Evaluation is no longer required at the moment
+            # case "structure":
+            #     # Set up prompts for structure evaluation and decision-making
+            #     evaluation_prompt = ChatPromptTemplate.from_messages(
+            #         self.prompt_template.return_structure_evaluation_prompt()
+            #     )
+            #     decision_prompt = ChatPromptTemplate.from_messages(
+            #         self.prompt_template.return_decision_prompt()
+            #     )
+            #
+            #     # Create evaluation chain
+            #     evaluation_chain = (
+            #         evaluation_prompt
+            #         | self.model
+            #         | StrOutputParser()
+            #         | {"evaluation": RunnablePassthrough()}
+            #     )
+            #
+            #     # Create decision chain
+            #     decision_chain = (
+            #         decision_prompt
+            #         | self.model
+            #         | StrOutputParser()
+            #         | RunnableLambda(parse_string_to_boolean)
+            #     )
+            #
+            #     # Combine chains for structure evaluation
+            #     chain = (
+            #         evaluation_chain
+            #         | {"text": itemgetter("evaluation")}
+            #         | RunnableParallel(text=itemgetter("text"), decision=decision_chain)
+            #         | RunnableLambda(self.evaluation_summary_router)
+            #     )
 
             case _:
                 # Raise an error for invalid choices

--- a/article-harmonisation/agents/prompts.py
+++ b/article-harmonisation/agents/prompts.py
@@ -280,7 +280,7 @@ class AzurePrompts(LLMPrompt):
                 """
                 Objective: Assess the relevance of the article title by qualitatively comparing it with the content of the article, ensuring a detailed and contextual analysis.
 
-                Steps to Follow:
+                Steps to Follow -
                 1.  Identify the Title:
                 -   What is the title of the article?
 
@@ -321,13 +321,16 @@ class AzurePrompts(LLMPrompt):
             ),
             (
                 "system",
-                """ Instructions:
+                """
+                Instructions:
                 1.  Use the steps provided to qualitatively evaluate the relevance of the article title.
-                2.  Write a brief report based on your findings, including specific examples.""",
+                2.  Write a brief report based on your findings, including specific examples.
+                3.  Do NOT make any title suggestions or recommendations. Focus solely on the critique instead.
+                """,
             ),
             (
                 "human",
-                "Evaluate the following title:\n{title} \nUsing the following article:\n{article}",
+                "Evaluate the following title:\n{title}\n\nUsing the following article:\n{article}",
             ),
         ]
 
@@ -395,8 +398,9 @@ class AzurePrompts(LLMPrompt):
                 "system",
                 """
                 Instructions:
-                -   Use the steps provided to evaluate the relevance of the article's meta description.
-                -   Write a brief report based on your findings, including specific examples.
+                1.  Use the steps provided to evaluate the relevance of the article's meta description.
+                2.  Write a brief report based on your findings, including specific examples.
+                3.  Do NOT make any meta description suggestions or recommendations. Focus solely on the critique instead.
                 """,
             ),
             (

--- a/article-harmonisation/checks.py
+++ b/article-harmonisation/checks.py
@@ -358,7 +358,9 @@ def create_checks_graph(state: ChecksState) -> CompiledGraph:
     return app
 
 
-def load_evaluation_dataframe(full_data_filepath: str, ids_filepath: str) -> tuple[pd.DataFrame]:
+def load_evaluation_dataframe(
+    full_data_filepath: str, ids_filepath: str
+) -> tuple[pd.DataFrame]:
     """
     Load and prepare evaluation dataframe for article harmonisation.
 
@@ -476,8 +478,12 @@ if __name__ == "__main__":
 
     # Get dataframe of articles to be evaluated
     merged_data_filepath = f"{ROOT_DIR}/article-harmonisation/data/merged_data.parquet"
-    ids_to_optimise_filepath = f"{ROOT_DIR}/article-harmonisation/data/ids_for_optimisation.csv"
-    df_keep, df_evaluated = load_evaluation_dataframe(merged_data_filepath, ids_to_optimise_filepath)
+    ids_to_optimise_filepath = (
+        f"{ROOT_DIR}/article-harmonisation/data/ids_for_optimisation.csv"
+    )
+    df_keep, df_evaluated = load_evaluation_dataframe(
+        merged_data_filepath, ids_to_optimise_filepath
+    )
 
     # Note: n can be adjusted as and when needed.
     # Usually, lower n is useful for generating evaluations in a more stable manner

--- a/article-harmonisation/states/definitions.py
+++ b/article-harmonisation/states/definitions.py
@@ -27,6 +27,7 @@ class ArticleInputs(TypedDict):
     article_category_names: Union[str, Optional[list[str]]]
     page_views: Union[int, Optional[list[int]]]
 
+
 class SkipLLMEvals(TypedDict):
     """
     A dictionary type definition for storing input data related to skipping LLM evaluations. This is typically used when

--- a/article-harmonisation/states/definitions.py
+++ b/article-harmonisation/states/definitions.py
@@ -27,6 +27,20 @@ class ArticleInputs(TypedDict):
     article_category_names: Union[str, Optional[list[str]]]
     page_views: Union[int, Optional[list[int]]]
 
+class SkipLLMEvals(TypedDict):
+    """
+    A dictionary type definition for storing input data related to skipping LLM evaluations. This is typically used when
+    running into errors raised from the Azure Content FFilter
+
+    Attributes:
+        decision (bool): Flag indicating if the LLM evaluations should be skipped.
+        explanation (str): A string indicating why the LLM evaluations should be skipped. Typically derived from the error
+            message
+    """
+
+    decision: bool
+    explanation: Optional[str]
+
 
 class ContentFlags(TypedDict):
     """

--- a/article-harmonisation/utils/formatters.py
+++ b/article-harmonisation/utils/formatters.py
@@ -368,6 +368,33 @@ def format_checks_outputs(checks: dict) -> dict:
     This function processes the input dictionary `checks` containing results from multiple content checks (such as flags
     and decisions based on rule-based and LLM-based assessments) and formats these into a comprehensive output dictionary.
 
+    These are the dictionary keys:
+        -   "article_id",
+        -   "title",
+        -   "url",
+        -   "content category",
+        -   "article category names",
+        -   "page views",
+        -   "Skipped LLM Evaluations",
+        -   "Reason for Skipping LLM Evaluations"
+        -   "overall flags",
+        -   "overall title flags",
+        -   "long title",
+        -   "irrelevant title",
+        -   "reason for irrelevant title",
+        -   "overall meta description flags",
+        -   "meta description",
+        -   "meta description not within 70 and 160 characters",
+        -   "irrelevant meta description",
+        -   "reason for irrelevant meta description",
+        -   "overall content flags",
+        -   "poor readability",
+        -   "reason for poor readability",
+        -   "insufficient content",
+        -   "Action",
+        -   "Reason for Action (IMPT for Cancellation)",
+        -   "Optional: additional content to add for optimisation"
+
     Args:
         checks (dict): A dictionary containing the results from content checks, including article inputs, content flags,
             title flags, and meta description flags.
@@ -383,10 +410,16 @@ def format_checks_outputs(checks: dict) -> dict:
     article_inputs = checks.get("article_inputs")
     article_id = int(article_inputs.get("article_id"))
     title = article_inputs.get("article_title")
+    meta_description = article_inputs.get("meta_desc")
     url = article_inputs.get("article_url")
     content_category = article_inputs.get("content_category")
     article_category_names = article_inputs.get("article_category_names")
     page_views = int(article_inputs.get("page_views"))
+
+    # Extracting Flags for Skipping LLM generation for evaluations & explanations
+    skip_llm_evaluations = checks.get("skip_llm_evaluations")
+    skip_llm_eval_decision = bool(skip_llm_evaluations.get("decision"), False)
+    skip_llm_eval_explanation = skip_llm_evaluations.get("explanation", None)
 
     # Extracting Content flags (Rule-based) from the checks dictionary
     content_flags = checks.get("content_flags")
@@ -399,8 +432,6 @@ def format_checks_outputs(checks: dict) -> dict:
     readability_explanation = content_judge.get("readability", {}).get(
         "explanation", None
     )
-    structure_decision = bool(content_judge.get("structure").get("decision"))
-    structure_explanation = content_judge.get("structure").get("explanation", None)
 
     # Extracting Title flags (Rule-based) from the checks dictionary
     title_flags = checks.get("title_flags")
@@ -408,8 +439,10 @@ def format_checks_outputs(checks: dict) -> dict:
 
     # Extracting Title flags (LLM-based) from the checks dictionary
     title_judge = checks.get("title_judge")
-    irrelevant_title_decision = bool(title_judge.get("title").get("decision"))
-    irrelevant_title_explanation = title_judge.get("title").get("explanation", None)
+    irrelevant_title_decision = bool(
+        title_judge.get("title", {}).get("decision", False)
+    )
+    irrelevant_title_explanation = title_judge.get("title", {}).get("explanation", None)
 
     # Extracting Meta description flags (Rule-based) from the checks dictionary
     meta_flags = checks.get("meta_flags")
@@ -417,8 +450,10 @@ def format_checks_outputs(checks: dict) -> dict:
 
     # Extracting Meta description flags (LLM-based) from the checks dictionary
     meta_judge = checks.get("meta_judge")
-    irrelevant_meta_desc_decision = bool(meta_judge.get("meta_desc").get("decision"))
-    irrelevant_meta_desc_explanation = meta_judge.get("meta_desc").get(
+    irrelevant_meta_desc_decision = bool(
+        meta_judge.get("meta_desc", {}).get("decision", False)
+    )
+    irrelevant_meta_desc_explanation = meta_judge.get("meta_desc", {}).get(
         "explanation", None
     )
 
@@ -430,11 +465,14 @@ def format_checks_outputs(checks: dict) -> dict:
     result["article category names"] = article_category_names
     result["page views"] = page_views
 
+    # Check if LLM Evaluation is skipped for the article
+    result["Skipped LLM Evaluations"] = skip_llm_eval_decision
+    result["Reason for Skipping LLM Evaluations"] = skip_llm_eval_explanation
+
     # Overall flags based on content, title, and meta description checks
     result["overall flags"] = (
         poor_readability
         | insufficient_content
-        | structure_decision
         | long_title
         | irrelevant_title_decision
         | meta_not_within_char_count
@@ -451,6 +489,7 @@ def format_checks_outputs(checks: dict) -> dict:
     result["overall meta description flags"] = (
         meta_not_within_char_count | irrelevant_meta_desc_decision
     )
+    result["meta description"] = meta_description
     result["meta description not within 70 and 160 characters"] = (
         meta_not_within_char_count
     )
@@ -458,17 +497,14 @@ def format_checks_outputs(checks: dict) -> dict:
     result["reason for irrelevant meta description"] = irrelevant_meta_desc_explanation
 
     # Content-related flags and explanations
-    result["overall content flags"] = (
-        poor_readability | insufficient_content | structure_decision
-    )
+    result["overall content flags"] = poor_readability | insufficient_content
     result["poor readability"] = poor_readability
     result["reason for poor readability"] = readability_explanation
     result["insufficient content"] = insufficient_content
-    result["writing style needs improvement"] = structure_decision
-    result["reason for improving writing style"] = structure_explanation
 
     # Placeholder fields for further actions and additional content
     result["Action"] = ""
-    result["Additional Content"] = ""
+    result["Reason for Action (IMPT for Cancellation)"] = ""
+    result["Optional: additional content to add for optimisation"] = ""
 
     return result

--- a/article-harmonisation/utils/formatters.py
+++ b/article-harmonisation/utils/formatters.py
@@ -418,13 +418,13 @@ def format_checks_outputs(checks: dict) -> dict:
 
     # Extracting Flags for Skipping LLM generation for evaluations & explanations
     skip_llm_evaluations = checks.get("skip_llm_evaluations")
-    skip_llm_eval_decision = bool(skip_llm_evaluations.get("decision", False))
+    skip_llm_eval_decision = skip_llm_evaluations.get("decision", None)
     skip_llm_eval_explanation = skip_llm_evaluations.get("explanation", None)
 
     # Extracting Content flags (Rule-based) from the checks dictionary
     content_flags = checks.get("content_flags")
-    poor_readability = bool(content_flags.get("is_unreadable"))
-    insufficient_content = bool(content_flags.get("low_word_count"))
+    poor_readability = content_flags.get("is_unreadable")
+    insufficient_content = content_flags.get("low_word_count")
 
     # Extracting Content flags (LLM-based) from the checks dictionary
     content_judge = checks.get("content_judge")
@@ -435,23 +435,21 @@ def format_checks_outputs(checks: dict) -> dict:
 
     # Extracting Title flags (Rule-based) from the checks dictionary
     title_flags = checks.get("title_flags")
-    long_title = bool(title_flags.get("long_title"))
+    long_title = title_flags.get("long_title")
 
     # Extracting Title flags (LLM-based) from the checks dictionary
     title_judge = checks.get("title_judge")
-    irrelevant_title_decision = bool(
-        title_judge.get("title", {}).get("decision", False)
-    )
+    irrelevant_title_decision = title_judge.get("title", {}).get("decision", None)
     irrelevant_title_explanation = title_judge.get("title", {}).get("explanation", None)
 
     # Extracting Meta description flags (Rule-based) from the checks dictionary
     meta_flags = checks.get("meta_flags")
-    meta_not_within_char_count = bool(meta_flags.get("not_within_char_count"))
+    meta_not_within_char_count = meta_flags.get("not_within_char_count")
 
     # Extracting Meta description flags (LLM-based) from the checks dictionary
     meta_judge = checks.get("meta_judge")
-    irrelevant_meta_desc_decision = bool(
-        meta_judge.get("meta_desc", {}).get("decision", False)
+    irrelevant_meta_desc_decision = meta_judge.get("meta_desc", {}).get(
+        "decision", None
     )
     irrelevant_meta_desc_explanation = meta_judge.get("meta_desc", {}).get(
         "explanation", None
@@ -474,20 +472,20 @@ def format_checks_outputs(checks: dict) -> dict:
         poor_readability
         | insufficient_content
         | long_title
-        | irrelevant_title_decision
+        | bool(irrelevant_title_decision)
         | meta_not_within_char_count
-        | irrelevant_meta_desc_decision
+        | bool(irrelevant_meta_desc_decision)
     )
 
     # Title-related flags and explanations
-    result["overall title flags"] = long_title | irrelevant_title_decision
+    result["overall title flags"] = long_title | bool(irrelevant_title_decision)
     result["long title"] = long_title
     result["irrelevant title"] = irrelevant_title_decision
     result["reason for irrelevant title"] = irrelevant_title_explanation
 
     # Meta description-related flags and explanations
-    result["overall meta description flags"] = (
-        meta_not_within_char_count | irrelevant_meta_desc_decision
+    result["overall meta description flags"] = meta_not_within_char_count | bool(
+        irrelevant_meta_desc_decision
     )
     result["meta description"] = meta_description
     result["meta description not within 70 and 160 characters"] = (

--- a/article-harmonisation/utils/formatters.py
+++ b/article-harmonisation/utils/formatters.py
@@ -418,7 +418,7 @@ def format_checks_outputs(checks: dict) -> dict:
 
     # Extracting Flags for Skipping LLM generation for evaluations & explanations
     skip_llm_evaluations = checks.get("skip_llm_evaluations")
-    skip_llm_eval_decision = bool(skip_llm_evaluations.get("decision"), False)
+    skip_llm_eval_decision = bool(skip_llm_evaluations.get("decision", False))
     skip_llm_eval_explanation = skip_llm_evaluations.get("explanation", None)
 
     # Extracting Content flags (Rule-based) from the checks dictionary


### PR DESCRIPTION
## Updated definitions.py
- I added the SkipLLMEvals class to store the decision to skip LLM generation if the Content Filter is triggered for the Azure Content Filter. Will be outputted into the Excel file

## Updated prompts.py
- Formatted title evaluation prompt
- Added instructions NOT to make any title and meta description suggestions or recommendations.

## Updated models.py
- Commented out Writing Style Evaluation Chain as it is no longer used in the content evaluation llm node

## Updated checks.py
- Commented out Writing Style Evaluation Chain as it is no longer used in the content evaluation llm node
- Added SkipLLMEvals class to contain skip_llm flags when the Azure Content Filter is triggered.
- Commented out implementation within content_evaluation_llm_node
- Implemented exception handling for Azure Content Filter
- Implemented printing of traceback to std output
- Updated `load_evaluation_dataframe` function to load article IDs from a CSV file for easier management of optimisation checks
- Updated docstrings

## Updated formatters.py
- Amended bug for default value for skip_llm_eval_decision
- Updated functions to allow null values for flags esp in the case where content filter blocks llm-based evaluations
